### PR TITLE
Update api_notebook.ipynb to correct URL

### DIFF
--- a/api/api_notebook.ipynb
+++ b/api/api_notebook.ipynb
@@ -313,7 +313,7 @@
    "outputs": [],
    "source": [
     "# we are specifying our url and parameters here as variables\n",
-    "url = 'http://api.dp.la/v2/items/'\n",
+    "url = 'http://api.dp.la/v2/items'\n",
     "params = {'api_key' : key['api_key'], 'q' : 'goats+AND+cats'}"
    ]
   },


### PR DESCRIPTION
The url  `url = 'http://api.dp.la/v2/items/'` with slash causes a 404 error. Removing the slash to resolve the error.